### PR TITLE
Feature/dumpling return

### DIFF
--- a/netdumplings/console/snifty.py
+++ b/netdumplings/console/snifty.py
@@ -63,8 +63,12 @@ def network_sniffer(kitchen_name, interface, chefs, chef_modules, valid_chefs,
         kitchen_name, chef_poke_interval))
 
     sniffer_kitchen = netdumplings.DumplingKitchen(
-        name=kitchen_name, interface=interface, sniffer_filter=sniffer_filter,
-        chef_poke_interval=chef_poke_interval)
+        name=kitchen_name,
+        interface=interface,
+        sniffer_filter=sniffer_filter,
+        chef_poke_interval=chef_poke_interval,
+        dumpling_queue=dumpling_queue,
+    )
 
     # Instantiate all the valid DumplingChef classes and register them with
     # the kitchen.
@@ -76,7 +80,7 @@ def network_sniffer(kitchen_name, interface, chefs, chef_modules, valid_chefs,
             log.info("{0}: Registering {1}.{2} with kitchen".format(
                 kitchen_name, chef_module, chef_class_name))
             klass = getattr(mod, chef_class_name)
-            klass(kitchen=sniffer_kitchen, dumpling_queue=dumpling_queue)
+            klass(kitchen=sniffer_kitchen)
 
     sniffer_kitchen.run()
 

--- a/netdumplings/dumplingchef.py
+++ b/netdumplings/dumplingchef.py
@@ -13,8 +13,9 @@ class DumplingChef:
     you'll normally subclass DumplingChef and let nd-snifty take care of
     instantiating it.**
 
-    When instantiated, a DumplingChef registers its :meth:`packet_handler` and
-    :meth:`interval_handler` with the given ``kitchen``.
+    When instantiated, a DumplingChef registers itself with the given
+    ``kitchen`` which will take care of calling the chef's packet and interval
+    handlers.
 
     A DumplingChef can create many :class:`~Dumpling` objects, where a
     dumpling is a tasty bundle of information which (usually) describes some
@@ -22,8 +23,8 @@ class DumplingChef:
     have been sniffed so far; how many packets of various network layers have
     been sniffed; etc.
 
-    This class implements the following methods which can also be overridden
-    by subclasses:
+    This class implements the following methods which will usually be
+    overridden by subclasses:
 
     * :meth:`packet_handler`
     * :meth:`interval_handler`
@@ -32,109 +33,52 @@ class DumplingChef:
     # chef cannot be assigned to any kitchens via snifty.
     assignable_to_kitchen = True
 
-    _epoch = datetime.datetime.utcfromtimestamp(0)
-
-    def __init__(self, kitchen=None, dumpling_queue=None, receive_pokes=False):
+    def __init__(self, kitchen=None):
         """
         :param kitchen: The :class:`DumplingKitchen` which is providing the
             network packet ingredients used to create the dumplings.
-        :param dumpling_queue: The :class:`multiprocessing.Queue` to send fresh
-            new dumplings to.
-        :param receive_pokes: Whether this chef wants to receive time-interval
-            pokes to its interval_handler.
         """
         self.kitchen = kitchen
-        self.dumpling_queue = dumpling_queue
-        self.receive_pokes = receive_pokes
-
         self.name = type(self).__name__
         self.dumplings_sent_count = 0
         self._logger = logging.getLogger(__name__)
 
         if self.kitchen:
-            interval_handler = \
-                self.interval_handler if self.receive_pokes else False
-
-            self.kitchen.register_handler(
-                chef_name=self.name,
-                packet_handler=self.packet_handler,
-                interval_handler=interval_handler
-            )
+            self.kitchen.register_chef(self)
 
     def __repr__(self):
-        return (
-            '{}('
-            'kitchen={}, '
-            'dumpling_queue={}, '
-            'receive_pokes={})'.format(
-                type(self).__name__,
-                repr(self.kitchen),
-                repr(self.dumpling_queue),
-                self.receive_pokes,
-            )
-        )
+        return '{}(kitchen={})'.format(type(self).__name__, repr(self.kitchen))
 
     def packet_handler(self, packet):
         """
-        This handler is called automatically by `nd-snifty` whenever a new
-        packet has been sniffed.
+        Called automatically by `nd-snifty` whenever a new packet has been
+        sniffed.
 
-        This method is expected to be overridden by child classes.
-
-        This base implementation immediately sends a dumpling, the payload of
-        which will be a string representation of the packet.
+        This method is expected to be overridden by child classes. This base
+        implementation returns a payload which is the string representation of
+        the packet.
 
         :param packet: Network packet (from scapy).
+        :return: Dumpling payload.
         """
         payload = "{0}: {1}".format(type(self).__name__, packet.summary())
         self._logger.debug("{0}: Received packet: {1}",
                            self.name, packet.summary())
-        self.send_packet_dumpling(payload)
+
+        return payload
 
     def interval_handler(self, interval=None):
         """
-        This handler is called automatically at regular intervals by
-        `nd-snifty`.  Allows for time-based (rather than purely packet-based)
-        chefs to keep on cheffing even in the absence of fresh packets.
+        Called automatically at regular intervals by `nd-snifty`.  Allows for
+        time-based (rather than purely packet-based) chefs to keep on cheffing
+        even in the absence of fresh packets.
 
-        This method is expected to be overridden by child classes.
-
-        This base implementation does nothing.
+        This method is expected to be overridden by child classes. This base
+        implementation does nothing.
 
         :param interval: Frequency (in seconds) of the time interval pokes.
         """
         self._logger.debug(
             "{0}: Received interval_handler poke", self.name)
 
-    def _send_dumpling(self, payload, driver):
-        """
-        Initiates a send of a dumpling to all the dumpling eaters.
-
-        :param payload: The dumpling payload.  Can be anything which is JSON
-            serializable.  It's up to the dumpling eaters to make sense of it.
-        :param driver: The DumplingDriver; either ``DumplingDriver.packet`` or
-            ``DumplingDriver.interval``.
-        """
-        dumpling = Dumpling(chef=self, driver=driver, payload=payload)
-        dumpling_json = dumpling()
-        self.dumpling_queue.put(dumpling_json)
-        self._logger.debug("{0}: Sent dumpling, {1} bytes".format(
-            self.name, len(dumpling_json)))
-
-    def send_interval_dumpling(self, payload):
-        """
-        Initiates a send of an interval dumpling to all dumpling eaters.
-
-        :param payload: The dumpling payload.  Can be anything which is JSON
-            serializable.  It's up to the dumpling eaters to make sense of it.
-        """
-        self._send_dumpling(payload, driver=DumplingDriver.interval)
-
-    def send_packet_dumpling(self, payload):
-        """
-        Initiates a send of a packet dumpling to all dumpling eaters.
-
-        :param payload: The dumpling payload.  Can be anything which is JSON
-            serializable.  It's up to the dumpling eaters to make sense of it.
-        """
-        self._send_dumpling(payload, driver=DumplingDriver.packet)
+        return None

--- a/netdumplings/dumplingchef.py
+++ b/netdumplings/dumplingchef.py
@@ -1,7 +1,4 @@
-import datetime
 import logging
-
-from netdumplings import Dumpling, DumplingDriver
 
 
 class DumplingChef:

--- a/netdumplings/dumplingchefs/arpchef.py
+++ b/netdumplings/dumplingchefs/arpchef.py
@@ -22,10 +22,8 @@ class ARPChef(DumplingChef):
     request = 1
     reply = 2
 
-    def __init__(self, kitchen=None, dumpling_queue=None, receive_pokes=False):
-        super().__init__(kitchen=kitchen, dumpling_queue=dumpling_queue,
-                         receive_pokes=receive_pokes)
-
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.ip_mac = {}
 
     def packet_handler(self, packet):
@@ -67,4 +65,4 @@ class ARPChef(DumplingChef):
             # Remember this IP -> MAC mapping.
             self.ip_mac[arp.psrc] = arp.hwsrc
 
-        self.send_packet_dumpling(payload)
+        return payload

--- a/netdumplings/dumplingchefs/dnslookupchef.py
+++ b/netdumplings/dumplingchefs/dnslookupchef.py
@@ -40,11 +40,8 @@ class DNSLookupChef(DumplingChef):
             }
         }
     """
-    def __init__(self, kitchen=None, dumpling_queue=None, receive_pokes=True):
-        """
-        """
-        super().__init__(kitchen=kitchen, dumpling_queue=dumpling_queue,
-                         receive_pokes=receive_pokes)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.lookups_seen = {}
 
     def packet_handler(self, packet):
@@ -82,7 +79,7 @@ class DNSLookupChef(DumplingChef):
             }
         }
 
-        self.send_packet_dumpling(payload)
+        return payload
 
     def interval_handler(self, interval=None):
         """
@@ -94,4 +91,4 @@ class DNSLookupChef(DumplingChef):
             'lookups_seen': self.lookups_seen
         }
 
-        self.send_interval_dumpling(payload)
+        return payload

--- a/netdumplings/dumplingchefs/packetcountchef.py
+++ b/netdumplings/dumplingchefs/packetcountchef.py
@@ -23,9 +23,8 @@ class PacketCountChef(DumplingChef):
             }
         }
     """
-    def __init__(self, kitchen=None, dumpling_queue=None, receive_pokes=True):
-        super().__init__(kitchen=kitchen, dumpling_queue=dumpling_queue,
-                         receive_pokes=receive_pokes)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.packet_counts = defaultdict(int)
         self.poke_count = 0
 
@@ -37,14 +36,16 @@ class PacketCountChef(DumplingChef):
         :param packet: Packet from nd-snifty.
         """
         self.packet_counts[packet.name] += 1
+
         while packet.payload:
             packet = packet.payload
             self.packet_counts[packet.name] += 1
+
+        return None
 
     def interval_handler(self, interval=None):
         """
         Makes a dumpling at regular intervals which lists all the layers seen
         in all the packets so far, and the count for each layer.
         """
-        payload = {'packet_counts': self.packet_counts}
-        self.send_interval_dumpling(payload)
+        return {'packet_counts': self.packet_counts}

--- a/tests/console/test_snifty.py
+++ b/tests/console/test_snifty.py
@@ -203,13 +203,13 @@ class TestSniftyNetworkSniffer:
             interface=interface,
             sniffer_filter=sniffer_filter,
             chef_poke_interval=chef_poke_interval,
+            dumpling_queue=dumpling_queue,
         )
 
         mock_dumpling_kitchen.return_value.run.assert_called_once()
 
         chef_class_callable.assert_called_once_with(
             kitchen=mock_dumpling_kitchen.return_value,
-            dumpling_queue=dumpling_queue,
         )
 
 

--- a/tests/dumpling_chefs/test_packetcountchef.py
+++ b/tests/dumpling_chefs/test_packetcountchef.py
@@ -42,18 +42,14 @@ class TestPacketCountChef:
         assert chef.packet_counts['Raw'] == 2
         assert chef.packet_counts['TCP'] == 2
 
-    def test_interval_handler(self, mocker):
+    def test_interval_handler(self):
         """
-        Test that a call to the interval handler sends an interval dumpling
-        which contains the packet count summaries.
+        Test that a call to the interval handler returns a dumpling which
+        contains the packet count summaries.
         """
         chef = PacketCountChef()
-        mock_send_interval_dumpling = mocker.patch.object(
-            chef, 'send_interval_dumpling'
-        )
+        dumpling = chef.interval_handler()
 
-        chef.interval_handler()
-
-        mock_send_interval_dumpling.assert_called_once_with({
+        assert dumpling == {
             'packet_counts': chef.packet_counts,
-        })
+        }

--- a/tests/test_dumplingkitchen.py
+++ b/tests/test_dumplingkitchen.py
@@ -1,8 +1,9 @@
 import importlib
+import json
 
 import pytest
 
-from netdumplings import DumplingKitchen
+from netdumplings import DumplingKitchen, DumplingChef, DumplingDriver
 
 
 class TestDumplingKitchen:
@@ -20,8 +21,7 @@ class TestDumplingKitchen:
         assert kitchen.filter == 'tcp'
         assert kitchen.chef_poke_interval == 5
 
-        assert len(kitchen._packet_handlers) == 0
-        assert len(kitchen._interval_handlers) == 0
+        assert len(kitchen._chefs) == 0
 
     def test_init_with_overrides(self):
         """
@@ -39,38 +39,24 @@ class TestDumplingKitchen:
         assert kitchen.filter == 'test filter'
         assert kitchen.chef_poke_interval == 10
 
-        assert len(kitchen._packet_handlers) == 0
-        assert len(kitchen._interval_handlers) == 0
+        assert len(kitchen._chefs) == 0
 
-    def test_handler_registration(self):
+    def test_chef_registration(self):
         """
-        Test registration of packet and interval handlers.
+        Test registration of chefs with the kitchen.
         """
         kitchen = DumplingKitchen()
 
-        assert len(kitchen._packet_handlers) == 0
-        assert len(kitchen._interval_handlers) == 0
+        assert len(kitchen._chefs) == 0
 
-        # For these tests we don't care that we're not registering callables.
+        test_chef_1 = DumplingChef()
+        test_chef_2 = DumplingChef()
 
-        kitchen.register_handler(
-            chef_name='TestChefOne',
-            packet_handler='TestPacketHandlerOne',
-        )
+        kitchen.register_chef(test_chef_1)
+        assert kitchen._chefs == [test_chef_1]
 
-        assert kitchen._packet_handlers == ['TestPacketHandlerOne']
-        assert len(kitchen._interval_handlers) == 0
-
-        kitchen.register_handler(
-            chef_name='TestChefTwo',
-            packet_handler='TestPacketHandlerTwo',
-            interval_handler='TestIntervalHandlerOne',
-        )
-
-        assert kitchen._packet_handlers == [
-            'TestPacketHandlerOne', 'TestPacketHandlerTwo'
-        ]
-        assert kitchen._interval_handlers == ['TestIntervalHandlerOne']
+        kitchen.register_chef(test_chef_2)
+        assert kitchen._chefs == [test_chef_1, test_chef_2]
 
     def test_repr(self):
         """
@@ -78,14 +64,16 @@ class TestDumplingKitchen:
         """
         kitchen = DumplingKitchen()
         assert repr(kitchen) == (
-            "DumplingKitchen(name='{}', "
-            "interface='{}', "
-            "sniffer_filter='{}', "
-            "chef_poke_interval={})".format(
-                kitchen.name,
-                kitchen.interface,
-                kitchen.filter,
-                kitchen.chef_poke_interval,
+            "DumplingKitchen(name={}, "
+            "interface={}, "
+            "sniffer_filter={}, "
+            "chef_poke_interval={} "
+            "dumpling_queue={})".format(
+                repr(kitchen.name),
+                repr(kitchen.interface),
+                repr(kitchen.filter),
+                repr(kitchen.chef_poke_interval),
+                repr(kitchen.dumpling_queue),
             )
         )
 
@@ -94,28 +82,35 @@ class TestHandlerInvocations:
     """
     Test DumplingKitchen invocations of the packet and interval handlers.
     """
-    def test_packet_handling(self, mocker):
+    def test_packet_processing(self, mocker):
         """
-        Test invocations of the packet handlers.
+        Test invocation of the packet handlers.
         """
         kitchen = DumplingKitchen()
 
-        # Set up two valid mock packet handlers (pretending to be chef packet
-        # handlers).
-        mock_handler_1 = mocker.Mock()
-        mock_handler_2 = mocker.Mock()
-        kitchen._packet_handlers = [mock_handler_1, mock_handler_2]
+        # Set up two valid chefs. One of them returns a dumpling when given a
+        # packet, and the other one doesn't.
+        mock_chef_with_packet_dumpling = mocker.Mock()
+        mock_chef_with_no_packet_dumpling = mocker.Mock()
+
+        mock_chef_with_packet_dumpling.packet_handler.return_value = 'dumpling'
+        mock_chef_with_no_packet_dumpling.packet_handler.return_value = None
+
+        kitchen._chefs = [
+            mock_chef_with_packet_dumpling,
+            mock_chef_with_no_packet_dumpling,
+        ]
 
         packet = 'test_packet'
-
         kitchen._process_packet(packet)
 
-        # Now check that that the two mock packet handlers got called as
-        # expected.
-        mock_handler_1.assert_called_once_with(packet)
-        mock_handler_2.assert_called_once_with(packet)
+        # Check that we only sent one packet dumpling.
+        kitchen._send_packet_dumpling.assert_called_once_with(
+            mock_chef_with_packet_dumpling,
+            'dumpling'
+        )
 
-    def test_packet_handling_with_broken_handler(self, mocker):
+    def test_packet_processing_with_broken_handler(self, mocker):
         """
         Test invocations of the packet handlers where one of them raises an
         exception, which should result in an exception-level log entry being
@@ -123,24 +118,31 @@ class TestHandlerInvocations:
         """
         kitchen = DumplingKitchen()
 
-        # Set up a valid packet handler, and a paxket handler which raises an
-        # exception. The exception should only result in a log entry being
-        # made.
-        mock_handler_1 = mocker.Mock()
-        mock_handler_2 = mocker.Mock(side_effect=KeyError)
-        kitchen._packet_handlers = [mock_handler_1, mock_handler_2]
+        # Set up two valid chefs. One of them returns a dumpling when given a
+        # packet, and the raises an exception.
+        mock_chef_with_packet_dumpling = mocker.Mock()
+        mock_chef_with_no_packet_dumpling = mocker.Mock()
+
+        mock_chef_with_packet_dumpling.packet_handler.return_value = 'dumpling'
+        mock_chef_with_no_packet_dumpling.packet_handler.side_effect = KeyError
+
+        kitchen._chefs = [
+            mock_chef_with_packet_dumpling,
+            mock_chef_with_no_packet_dumpling,
+        ]
 
         # Add a spy on the logger so we can check it got called.
         mocker.spy(kitchen._logger, 'exception')
 
         packet = 'test_packet'
-
         kitchen._process_packet(packet)
 
-        # Check that the two handlers got called, and that an exception-level
-        # log was created.
-        mock_handler_1.assert_called_once_with(packet)
-        mock_handler_2.assert_called_once_with(packet)
+        # Check that we only sent one packet dumpling, and that an
+        # exception-level log was created.
+        kitchen._send_packet_dumpling.assert_called_once_with(
+            mock_chef_with_packet_dumpling,
+            'dumpling'
+        )
         kitchen._logger.exception.assert_called_once()
 
     def test_chef_poking(self, mocker):
@@ -152,29 +154,52 @@ class TestHandlerInvocations:
 
         # _poke_chefs() runs in an infinite loop which we need to break out of.
         # We do that by setting a side effect on the mocked call to sleep()
-        # which will raise an Exception. This doesn't interfere with being able
-        # to determine the value passed to sleep().
+        # which will raise a RuntimeError. This doesn't interfere with being
+        # able to determine the value passed to sleep().
         mock_sleep = mocker.patch(
-            'netdumplings.dumplingkitchen.sleep', side_effect=Exception
+            'netdumplings.dumplingkitchen.sleep', side_effect=RuntimeError
         )
 
-        # Set up two valid mock interval handlers (pretending to be chef
-        # interval handlers).
-        mock_handler_1 = mocker.Mock()
-        mock_handler_2 = mocker.Mock()
-        kitchen._interval_handlers = [mock_handler_1, mock_handler_2]
+        # Set up two valid chefs. One of them returns a dumpling when poked and
+        # and the other one doesn't.
+        mock_chef_with_interval_dumpling = mocker.Mock()
+        mock_chef_with_no_interval_dumpling = mocker.Mock()
 
-        # Run the function under test. We've configured it to throw an
-        # exception the first time it attempts to sleep.
-        with pytest.raises(Exception):
+        dumpling_interval_handler = (
+            mock_chef_with_interval_dumpling.interval_handler
+        )
+        no_dumpling_interval_handler = (
+            mock_chef_with_no_interval_dumpling.interval_handler
+        )
+
+        dumpling_interval_handler.return_value = 'dumpling'
+        no_dumpling_interval_handler.return_value = None
+
+        kitchen._chefs = [
+            mock_chef_with_interval_dumpling,
+            mock_chef_with_no_interval_dumpling,
+        ]
+
+        # Run once through the poker infinite loop.
+        with pytest.raises(RuntimeError):
             kitchen._poke_chefs(test_interval)
 
-        # Now check that that the two mock interval handlers got called as
-        # expected, and that the mock sleep also got called as expected.
+        # Check that we were asked to sleep by the test interval.
         mock_sleep.assert_called_once_with(test_interval)
 
-        mock_handler_1.assert_called_once_with(interval=test_interval)
-        mock_handler_2.assert_called_once_with(interval=test_interval)
+        # Check that the two interval handlers were invoked, and that the one
+        # that returned a dumpling resulted in that dumpling being sent.
+        dumpling_interval_handler.assert_called_once_with(
+            interval=test_interval
+        )
+        no_dumpling_interval_handler.assert_called_once_with(
+            interval=test_interval
+        )
+
+        kitchen._send_interval_dumpling.assert_called_once_with(
+            mock_chef_with_interval_dumpling,
+            'dumpling'
+        )
 
     def test_chef_poking_with_broken_handler(self, mocker):
         """
@@ -184,28 +209,116 @@ class TestHandlerInvocations:
         """
         test_interval = 3
         kitchen = DumplingKitchen(chef_poke_interval=test_interval)
+
         mocker.patch(
-            'netdumplings.dumplingkitchen.sleep', side_effect=Exception
+            'netdumplings.dumplingkitchen.sleep', side_effect=RuntimeError
         )
 
-        # Set up a valid interval handler, and an interval handler which raises
-        # an exception. The exception should only result in a log entry being
-        # made.
-        mock_handler_1 = mocker.Mock()
-        mock_handler_2 = mocker.Mock(side_effect=KeyError)
-        kitchen._interval_handlers = [mock_handler_1, mock_handler_2]
+        # Set up one valid chefs which returns an interval dumpling, and one
+        # chef which raises an exception in its interval handler.
+        # and the other one doesn't.
+        mock_chef_with_interval_dumpling = mocker.Mock()
+        mock_chef_with_interval_error = mocker.Mock()
 
-        # Add a spy on the logger so we can check it got called.
-        mocker.spy(kitchen._logger, 'exception')
+        dumpling_interval_handler = (
+            mock_chef_with_interval_dumpling.interval_handler
+        )
+        error_interval_handler = (
+            mock_chef_with_interval_error.interval_handler
+        )
 
-        with pytest.raises(Exception):
+        dumpling_interval_handler.return_value = 'dumpling'
+        error_interval_handler.side_effect = KeyError
+
+        kitchen._chefs = [
+            mock_chef_with_interval_dumpling,
+            mock_chef_with_interval_error,
+        ]
+
+        # Run once through the poker infinite loop.
+        with pytest.raises(RuntimeError):
             kitchen._poke_chefs(test_interval)
 
-        # Check that the two handlers got called, and that an exception-level
-        # log was created.
-        mock_handler_1.assert_called_once_with(interval=test_interval)
-        mock_handler_2.assert_called_once_with(interval=test_interval)
+        # Check that the valid dumpling was sent, and that we logged an
+        # exception for the other chef.
+        kitchen._send_interval_dumpling.assert_called_once_with(
+            mock_chef_with_interval_dumpling,
+            'dumpling'
+        )
         kitchen._logger.exception.assert_called_once()
+
+
+class TestDumplingSends:
+    """
+    Test the sending of dumplings.
+    """
+    def test_send_interval_dumpling(self, mocker):
+        """
+        Test sending an interval dumpling. It should invoke _send_dumpling
+        with the interval dumpling driver.
+        """
+        kitchen = DumplingKitchen()
+        chef = DumplingChef()
+
+        mocker.patch.object(kitchen, '_send_dumpling')
+
+        test_payload = {'one': 1, 'two': 2}
+        kitchen._send_interval_dumpling(chef, test_payload)
+
+        kitchen._send_dumpling.assert_called_once_with(
+            chef, driver=DumplingDriver.interval, payload=test_payload
+        )
+
+    def test_send_packet_dumpling(self, mocker, mock_kitchen):
+        """
+        Test sending an interval dumpling. It should invoke _send_dumpling
+        with the packet dumpling driver.
+        """
+        kitchen = DumplingKitchen()
+        chef = DumplingChef()
+
+        mocker.patch.object(kitchen, '_send_dumpling')
+
+        test_payload = {'one': 1, 'two': 2}
+        kitchen._send_packet_dumpling(chef, test_payload)
+
+        kitchen._send_dumpling.assert_called_once_with(
+            chef, driver=DumplingDriver.packet, payload=test_payload
+        )
+
+    def test_dumpling_send(self, mocker, test_dumpling_dns):
+        """
+        Test the _send_dumpling method to ensure that it calls make() on a new
+        Dumpling and puts the resulting dumpling contents onto the queue.
+        """
+        test_payload_json = json.dumps(test_dumpling_dns)
+
+        mock_dumpling_class = mocker.patch(
+            'netdumplings.dumplingkitchen.Dumpling'
+        )
+
+        mock_dumpling_class.return_value.make.return_value = (
+            test_payload_json
+        )
+
+        mock_chef = mocker.Mock()
+        mock_queue = mocker.Mock()
+
+        kitchen = DumplingKitchen(dumpling_queue=mock_queue)
+
+        kitchen._send_dumpling(
+            chef=mock_chef,
+            driver=DumplingDriver.packet,
+            payload=test_dumpling_dns['payload']
+        )
+
+        mock_dumpling_class.assert_called_once_with(
+            chef=mock_chef,
+            driver=DumplingDriver.packet,
+            payload=test_dumpling_dns['payload']
+        )
+
+        mock_queue.put.assert_called_once_with(test_payload_json)
 
 
 class TestChefDiscovery:
@@ -218,7 +331,7 @@ class TestChefDiscovery:
         """
         kitchen = DumplingKitchen()
 
-        # This will actually allow the imports to take place, so we're
+        # WARNING: This will actually allow the imports to take place, so we're
         # technically letting this test pollute our namespace.
         spy_importlib = mocker.spy(importlib, 'import_module')
 
@@ -255,7 +368,7 @@ class TestChefDiscovery:
             'MoreTestChefOne', 'MoreTestChefTwo'
         ])
 
-    def test_chef_discovery_with_invalid_nodule(self):
+    def test_chef_discovery_with_invalid_module(self):
         """
         Test that attempting to discover chefs from an invalid module
         successfully results in an error for that module, while chefs from a


### PR DESCRIPTION
DumplingChef classes now return the dumpling payloads from their packet and interval handlers. The DumplingKitchen takes care of wrapping the payloads (creating the Dumplings) and sending them to the DumplingHub. This makes the interface a little cleaner for Chef writers, but it does muddy the Chef/Kitchen delineation somewhat.