### PR TITLE
Rename CLI scripts

### DIFF
--- a/netdumplings/_shared.py
+++ b/netdumplings/_shared.py
@@ -20,10 +20,11 @@ ND_CLOSE_MSGS = {
 LOGGING_CONFIG_FILE = os.path.join(
     os.path.dirname(__file__), 'data', 'logging.json'
 )
-DEFAULT_SHIFTY_HOST = 'localhost'
-DEFAULT_SHIFTY_IN_PORT = 11347
-DEFAULT_SHIFTY_OUT_PORT = 11348
-SHIFTY_STATUS_FREQ = 5
+
+HUB_HOST = 'localhost'
+HUB_IN_PORT = 11347
+HUB_OUT_PORT = 11348
+HUB_STATUS_FREQ = 5
 
 
 def configure_logging(log_level=logging.INFO, config_file=LOGGING_CONFIG_FILE):
@@ -69,9 +70,9 @@ def configure_logging(log_level=logging.INFO, config_file=LOGGING_CONFIG_FILE):
 
 def validate_dumpling(dumpling_json):
     """
-    Validates a dumpling received from (or about to be sent to) `nd-shifty`.
-    Validation involves ensuring that it's valid JSON and that it includes a
-    ``metadata.chef`` key.
+    Validates a dumpling received from (or about to be sent to) the dumpling
+    hub. Validation involves ensuring that it's valid JSON and that it includes
+    a ``metadata.chef`` key.
 
     :param dumpling_json: The dumpling JSON.
     :raise: :class:`netdumplings.exceptions.InvalidDumpling` if the

--- a/netdumplings/console/__init__.py
+++ b/netdumplings/console/__init__.py
@@ -1,14 +1,14 @@
-from .printer import printer_cli
-from .shifty import shifty_cli
-from .shiftydetails import shiftydetails_cli
-from .shiftysummary import shiftysummary_cli
-from .snifty import snifty_cli
+from .hub import hub_cli
+from .hubdetails import hubdetails_cli
+from .hubstatus import hubstatus_cli
+from .print import print_cli
+from .sniff import sniff_cli
 
 
 (
-    printer_cli,
-    shifty_cli,
-    shiftydetails_cli,
-    shiftysummary_cli,
-    snifty_cli,
+    hub_cli,
+    hubdetails_cli,
+    hubstatus_cli,
+    print_cli,
+    sniff_cli,
 )

--- a/netdumplings/console/hub.py
+++ b/netdumplings/console/hub.py
@@ -5,8 +5,8 @@ import click
 import netdumplings
 from netdumplings.exceptions import NetDumplingsError
 from netdumplings._shared import (
-    configure_logging, DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_IN_PORT,
-    DEFAULT_SHIFTY_OUT_PORT, SHIFTY_STATUS_FREQ,
+    configure_logging, HUB_HOST, HUB_IN_PORT,
+    HUB_OUT_PORT, HUB_STATUS_FREQ,
 )
 
 from ._shared import CLICK_CONTEXT_SETTINGS
@@ -17,9 +17,9 @@ from ._shared import CLICK_CONTEXT_SETTINGS
 )
 @click.option(
     '--address', '-a',
-    help='Address where nd-shifty will send dumplings from.',
+    help='Address where nd-hub will send dumplings from.',
     metavar='HOSTNAME',
-    default=DEFAULT_SHIFTY_HOST,
+    default=HUB_HOST,
     show_default=True,
 )
 @click.option(
@@ -27,7 +27,7 @@ from ._shared import CLICK_CONTEXT_SETTINGS
     help='Port to receive incoming dumplings from.',
     metavar='PORT',
     type=click.INT,
-    default=DEFAULT_SHIFTY_IN_PORT,
+    default=HUB_IN_PORT,
     show_default=True,
 )
 @click.option(
@@ -35,7 +35,7 @@ from ._shared import CLICK_CONTEXT_SETTINGS
     help='Port to send outgoing dumplings on.',
     metavar='PORT',
     type=click.INT,
-    default=DEFAULT_SHIFTY_OUT_PORT,
+    default=HUB_OUT_PORT,
     show_default=True,
 )
 @click.option(
@@ -43,17 +43,17 @@ from ._shared import CLICK_CONTEXT_SETTINGS
     help='Frequency (in seconds) to send status dumplings.',
     metavar='SECONDS',
     type=click.INT,
-    default=SHIFTY_STATUS_FREQ,
+    default=HUB_STATUS_FREQ,
     show_default=True,
 )
 @click.version_option(version=netdumplings.__version__)
-def shifty_cli(address, in_port, out_port, status_freq):
+def hub_cli(address, in_port, out_port, status_freq):
     """
     The dumpling hub.
 
     Sends dumplings received from all kitchens (usually any running instances
-    of nd-snifty) to all dumpling eaters. All kitchens and eaters need to
-    connect to the nd-shifty --in-port or --out-port respectively.
+    of nd-sniff) to all dumpling eaters. All kitchens and eaters need to
+    connect to the nd-hub --in-port or --out-port respectively.
     """
     configure_logging()
 
@@ -67,9 +67,9 @@ def shifty_cli(address, in_port, out_port, status_freq):
     try:
         dumpling_hub.run()
     except NetDumplingsError as e:
-        print('shifty error: {0}'.format(e))
+        print('hub error: {0}'.format(e))
         sys.exit(1)
 
 
 if __name__ == '__main__':
-    shifty_cli()
+    hub_cli()

--- a/netdumplings/console/hubdetails.py
+++ b/netdumplings/console/hubdetails.py
@@ -1,7 +1,7 @@
 import click
 
 import netdumplings
-from netdumplings._shared import DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT
+from netdumplings._shared import HUB_HOST, HUB_OUT_PORT
 
 from ._shared import CLICK_CONTEXT_SETTINGS, printable_dumpling
 
@@ -9,21 +9,21 @@ from ._shared import CLICK_CONTEXT_SETTINGS, printable_dumpling
 PRINT_COLOR = False
 
 
-async def on_connect(shifty_uri, websocket):
+async def on_connect(hub_uri, websocket):
     """
-    Called when the connection to nd-shifty has been created.
+    Called when the connection to nd-hub has been created.
 
-    :param shifty_uri: The nd-shifty websocket URI.
-    :param websocket: The websocket object used for talking to nd-shifty
+    :param hub_uri: The nd-hub websocket URI.
+    :param websocket: The websocket object used for talking to nd-hub
         (websockets.WebSocketClientProtocol).
     """
-    print('Connected to nd-shifty at {0}'.format(shifty_uri))
+    print('Connected to nd-hub at {0}'.format(hub_uri))
     print('Waiting for a SystemStatus dumpling...')
 
 
 async def on_dumpling(dumpling):
     """
-    Called when a new dumpling is received from nd-shifty. Prints dumpling
+    Called when a new dumpling is received from nd-hub. Prints dumpling
     payload.
 
     :param dumpling: The freshly-made new dumpling.
@@ -35,11 +35,11 @@ async def on_dumpling(dumpling):
 
 async def on_connection_lost(e):
     """
-    Called when nd-shifty connection is lost.
+    Called when nd-hub connection is lost.
 
     :param e: The exception thrown during the connection close.
     """
-    print('\nLost connection to nd-shifty: {}'.format(e))
+    print('\nLost connection to nd-hub: {}'.format(e))
 
 
 # -----------------------------------------------------------------------------
@@ -48,17 +48,17 @@ async def on_connection_lost(e):
     context_settings=CLICK_CONTEXT_SETTINGS,
 )
 @click.option(
-    '--shifty', '-h',
-    help='Address where nd-shifty is sending dumplings from.',
+    '--hub', '-h',
+    help='Address where nd-hub is sending dumplings from.',
     metavar='HOST:PORT',
-    default='{}:{}'.format(DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT),
+    default='{}:{}'.format(HUB_HOST, HUB_OUT_PORT),
     show_default=True,
 )
 @click.option(
     '--eater-name', '-n',
-    help='Dumpling eater name for this tool when connecting to nd-shifty.',
+    help='Dumpling eater name for this tool when connecting to nd-hub.',
     metavar='EATER_NAME',
-    default='statuseater',
+    default='detailseater',
     show_default=True,
 )
 @click.option(
@@ -68,20 +68,20 @@ async def on_connection_lost(e):
     show_default=True,
 )
 @click.version_option(version=netdumplings.__version__)
-def shiftydetails_cli(shifty, eater_name, color):
+def hubdetails_cli(hub, eater_name, color):
     """
     A dumpling eater.
 
-    Connects to nd-shifty (the dumpling hub) and waits for a single
-    SystemStatus dumpling which it displays and then exits.
+    Connects to nd-hub (the dumpling hub) and waits for a single SystemStatus
+    dumpling which it displays the full contents of and then exits.
     """
     global PRINT_COLOR
     PRINT_COLOR = color
 
     eater = netdumplings.DumplingEater(
         name=eater_name,
-        shifty=shifty,
-        chefs=['SystemStatusChef'],
+        hub=hub,
+        chef_filter=['SystemStatusChef'],
         on_connect=on_connect,
         on_dumpling=on_dumpling,
         on_connection_lost=on_connection_lost,
@@ -93,4 +93,4 @@ def shiftydetails_cli(shifty, eater_name, color):
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':
-    shiftydetails_cli()
+    hubdetails_cli()

--- a/netdumplings/console/hubstatus.py
+++ b/netdumplings/console/hubstatus.py
@@ -4,7 +4,7 @@ import click
 import termcolor
 
 import netdumplings
-from netdumplings._shared import DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT
+from netdumplings._shared import HUB_HOST, HUB_OUT_PORT
 
 from ._shared import CLICK_CONTEXT_SETTINGS
 
@@ -12,23 +12,23 @@ from ._shared import CLICK_CONTEXT_SETTINGS
 PRINT_COLOR = False
 
 
-async def on_connect(shifty_uri, websocket):
+async def on_connect(hub_uri, websocket):
     """
-    Called when the connection to nd-shifty has been created.
+    Called when the connection to nd-hub has been created.
 
-    :param shifty_uri: The nd-shifty websocket URI.
-    :param websocket: The websocket object used for talking to nd-shifty
+    :param hub_uri: The nd-hub websocket URI.
+    :param websocket: The websocket object used for talking to nd-hub
         (websockets.WebSocketClientProtocol).
     :return: None
     """
-    print('Shifty status from {0}'.format(shifty_uri))
+    print('Shifty status from {0}'.format(hub_uri))
     print('Waiting for data... ', end='', flush=True)
 
 
 async def on_dumpling(dumpling):
     """
-    Called when a new dumpling is received from nd-shifty.  Prints information
-    about the current state of nd-shifty.
+    Called when a new dumpling is received from nd-hub.  Prints summary
+    information about the current state of nd-hub.
 
     :param dumpling: The freshly-made new dumpling.
     :return: None
@@ -74,12 +74,12 @@ async def on_dumpling(dumpling):
 
 async def on_connection_lost(e):
     """
-    Called when nd-shifty connection is lost.
+    Called when nd-hub connection is lost.
 
     :param e: The exception thrown during the connection close.
     :return: None
     """
-    print('\nLost connection to nd-shifty: {}'.format(e))
+    print('\nLost connection to nd-hub: {}'.format(e))
 
 
 # -----------------------------------------------------------------------------
@@ -88,15 +88,15 @@ async def on_connection_lost(e):
     context_settings=CLICK_CONTEXT_SETTINGS,
 )
 @click.option(
-    '--shifty', '-h',
-    help='Address where nd-shifty is sending dumplings from.',
+    '--hub', '-h',
+    help='Address where nd-hub is sending dumplings from.',
     metavar='HOST:PORT',
-    default='{}:{}'.format(DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT),
+    default='{}:{}'.format(HUB_HOST, HUB_OUT_PORT),
     show_default=True,
 )
 @click.option(
     '--eater-name', '-n',
-    help='Dumpling eater name for this tool when connecting to nd-shifty.',
+    help='Dumpling eater name for this tool when connecting to nd-hub.',
     metavar='EATER_NAME',
     default='statuseater',
     show_default=True,
@@ -108,21 +108,22 @@ async def on_connection_lost(e):
     show_default=True,
 )
 @click.version_option(version=netdumplings.__version__)
-def shiftysummary_cli(shifty, eater_name, color):
+def hubstatus_cli(hub, eater_name, color):
     """
     A dumpling eater.
 
-    Connects to nd-shifty (the dumpling hub) and prints information from any
-    SystemStatusChef dumplings. This is a system-monitoring dumpling eater
-    which can be used to keep an eye on nd-shifty.
+    Connects to nd-hub (the dumpling hub) and continually prints summary status
+    information from any SystemStatusChef dumplings. This is a
+    system monitoring dumpling eater which can be used to keep an eye on
+    nd-hub.
     """
     global PRINT_COLOR
     PRINT_COLOR = color
 
     eater = netdumplings.DumplingEater(
         name=eater_name,
-        shifty=shifty,
-        chefs=['SystemStatusChef'],
+        hub=hub,
+        chef_filter=['SystemStatusChef'],
         on_connect=on_connect,
         on_dumpling=on_dumpling,
         on_connection_lost=on_connection_lost,
@@ -132,4 +133,4 @@ def shiftysummary_cli(shifty, eater_name, color):
 
 
 if __name__ == '__main__':
-    shiftysummary_cli()
+    hubstatus_cli()

--- a/netdumplings/console/print.py
+++ b/netdumplings/console/print.py
@@ -4,7 +4,7 @@ import click
 import termcolor
 
 import netdumplings
-from netdumplings._shared import DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT
+from netdumplings._shared import HUB_HOST, HUB_OUT_PORT
 
 from ._shared import CLICK_CONTEXT_SETTINGS, printable_dumpling
 
@@ -12,7 +12,7 @@ from ._shared import CLICK_CONTEXT_SETTINGS, printable_dumpling
 class PrinterEater(netdumplings.DumplingEater):
     """
     A dumpling eater which displays dumpling information to the terminal as it
-    arrives from nd-shifty.
+    arrives from nd-hub.
     """
     def __init__(
             self,
@@ -21,7 +21,7 @@ class PrinterEater(netdumplings.DumplingEater):
             packet_dumplings=True,
             contents=True,
             color=True,
-            **kwargs
+            **kwargs,
     ):
         super().__init__(**kwargs)
 
@@ -31,20 +31,20 @@ class PrinterEater(netdumplings.DumplingEater):
         self._contents = contents
         self._color = color
 
-    async def on_connect(self, shifty_uri, websocket):
+    async def on_connect(self, hub_uri, websocket):
         """
-        Called when the connection to nd-shifty has been created.
+        Called when the connection to nd-hub has been created.
 
-        :param shifty_uri: The nd-shifty websocket URI.
-        :param websocket: The websocket object used for talking to nd-shifty
+        :param hub_uri: The nd-hub websocket URI.
+        :param websocket: The websocket object used for talking to nd-hub
             (websockets.WebSocketClientProtocol).
         """
-        print('Connected to nd-shifty at {0}'.format(shifty_uri))
+        print('Connected to nd-hub at {0}'.format(hub_uri))
         print('Waiting for dumplings...\n')
 
     async def on_dumpling(self, dumpling):
         """
-        Called when a new dumpling is received from nd-shifty. Prints the
+        Called when a new dumpling is received from nd-hub. Prints the
         dumpling summary and contents.
 
         :param dumpling: The freshly-made new dumpling.
@@ -92,11 +92,11 @@ class PrinterEater(netdumplings.DumplingEater):
 
     async def on_connection_lost(self, e):
         """
-        Called when the nd-shifty connection is lost.
+        Called when the nd-hub connection is lost.
 
         :param e: The exception thrown during the connection close.
         """
-        print('\nLost connection to nd-shifty: {}'.format(e))
+        print('\nLost connection to nd-hub: {}'.format(e))
 
 
 # -----------------------------------------------------------------------------
@@ -105,10 +105,10 @@ class PrinterEater(netdumplings.DumplingEater):
     context_settings=CLICK_CONTEXT_SETTINGS,
 )
 @click.option(
-    '--shifty', '-h',
-    help='Address where nd-shifty is sending dumplings from.',
+    '--hub', '-h',
+    help='Address where nd-hub is sending dumplings from.',
     metavar='HOST:PORT',
-    default='{}:{}'.format(DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT),
+    default='{}:{}'.format(HUB_HOST, HUB_OUT_PORT),
     show_default=True,
 )
 @click.option(
@@ -127,7 +127,7 @@ class PrinterEater(netdumplings.DumplingEater):
 )
 @click.option(
     '--eater-name', '-n',
-    help='Dumpling eater name for this tool when connecting to nd-shifty.',
+    help='Dumpling eater name for this tool when connecting to nd-hub.',
     default='printereater',
     metavar='EATER_NAME',
     show_default=True,
@@ -157,12 +157,12 @@ class PrinterEater(netdumplings.DumplingEater):
     show_default=True,
 )
 @click.version_option(version=netdumplings.__version__)
-def printer_cli(shifty, chef, kitchen, eater_name, interval_dumplings,
-                packet_dumplings, contents, color):
+def print_cli(hub, chef, kitchen, eater_name, interval_dumplings,
+              packet_dumplings, contents, color):
     """
     A dumpling eater.
 
-    Connects to nd-shifty (the dumpling hub) and prints the contents of the
+    Connects to nd-hub (the dumpling hub) and prints the contents of the
     dumplings made by the given chefs.
     """
     eater = PrinterEater(
@@ -172,7 +172,7 @@ def printer_cli(shifty, chef, kitchen, eater_name, interval_dumplings,
         contents=contents,
         color=color,
         name=eater_name,
-        shifty=shifty,
+        hub=hub,
         chefs=chef if chef else None,
     )
 
@@ -180,4 +180,4 @@ def printer_cli(shifty, chef, kitchen, eater_name, interval_dumplings,
 
 
 if __name__ == '__main__':
-    printer_cli()
+    print_cli()

--- a/netdumplings/dumplingchef.py
+++ b/netdumplings/dumplingchef.py
@@ -11,9 +11,9 @@ class DumplingChef:
     """
     Base class for all dumpling chefs.
 
-    **NOTE: DumplingChef objects are instantiated for you by nd-snifty. You
+    **NOTE: DumplingChef objects are instantiated for you by nd-sniff. You
     normally won't need to instantiate DumplingChef objects yourself.  Instead
-    you'll normally subclass DumplingChef and let nd-snifty take care of
+    you'll normally subclass DumplingChef and let nd-sniff take care of
     instantiating it.**
 
     When instantiated, a DumplingChef registers itself with the given
@@ -33,7 +33,7 @@ class DumplingChef:
     * :meth:`interval_handler`
     """
     # Setting assignable_to_kitchen to False (in a subclass) will ensure the
-    # chef cannot be assigned to any kitchens via snifty.
+    # chef cannot be assigned to any kitchens via nd-sniff.
     assignable_to_kitchen = True
 
     def __init__(
@@ -57,8 +57,8 @@ class DumplingChef:
 
     def packet_handler(self, packet: scapy.packet.Raw) -> JSONSerializable:
         """
-        Called automatically by `nd-snifty` whenever a new packet has been
-        sniffed.
+        Called automatically by the DumplingKitchen whenever a new packet has
+        been sniffed.
 
         This method is expected to be overridden by child classes. This base
         implementation returns a payload which is the string representation of
@@ -76,9 +76,9 @@ class DumplingChef:
     def interval_handler(
             self, interval: Optional[int] = None) -> JSONSerializable:
         """
-        Called automatically at regular intervals by `nd-snifty`.  Allows for
-        time-based (rather than purely packet-based) chefs to keep on cheffing
-        even in the absence of fresh packets.
+        Called automatically at regular intervals by the DumplingKitchen.
+        Allows for time-based (rather than purely packet-based) chefs to keep
+        on cheffing even in the absence of fresh packets.
 
         This method is expected to be overridden by child classes. This base
         implementation does nothing.

--- a/netdumplings/dumplingchefs/arpchef.py
+++ b/netdumplings/dumplingchefs/arpchef.py
@@ -28,10 +28,10 @@ class ARPChef(DumplingChef):
 
     def packet_handler(self, packet):
         """
-        Processes a packet from nd-snifty.  Makes a dumpling summarizing the
+        Processes a packet from nd-sniff.  Makes a dumpling summarizing the
         contents of each each valid ARP packet.
 
-        :param packet: Packet from nd-snifty.
+        :param packet: Packet from nd-sniff.
         """
         if not packet.haslayer("ARP"):
             return

--- a/netdumplings/dumplingchefs/dnslookupchef.py
+++ b/netdumplings/dumplingchefs/dnslookupchef.py
@@ -46,10 +46,10 @@ class DNSLookupChef(DumplingChef):
 
     def packet_handler(self, packet):
         """
-        Processes a packet from nd-snifty.  Makes a dumpling summarizing the
+        Processes a packet from nd-sniff.  Makes a dumpling summarizing the
         contents of each each valid DNS lookup.
 
-        :param packet: Packet from nd-snifty.
+        :param packet: Packet from nd-sniff.
         """
         if not packet.haslayer('DNS'):
             return

--- a/netdumplings/dumplingchefs/packetcountchef.py
+++ b/netdumplings/dumplingchefs/packetcountchef.py
@@ -30,10 +30,10 @@ class PacketCountChef(DumplingChef):
 
     def packet_handler(self, packet):
         """
-        Processes a packet from nd-snifty.  Adds 1 to the layer count for
-        each layer found in the packet.  This does not make any dumplings.
+        Processes a packet from nd-sniff.  Adds 1 to the layer count for each
+        layer found in the packet.  This does not make any dumplings.
 
-        :param packet: Packet from nd-snifty.
+        :param packet: Packet from nd-sniff.
         """
         self.packet_counts[packet.name] += 1
 

--- a/netdumplings/dumplinghub.py
+++ b/netdumplings/dumplinghub.py
@@ -9,31 +9,31 @@ from .dumpling import Dumpling, DumplingDriver
 from .exceptions import InvalidDumpling, NetDumplingsError
 
 from ._shared import (
-    validate_dumpling, DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_IN_PORT,
-    DEFAULT_SHIFTY_OUT_PORT, SHIFTY_STATUS_FREQ,
+    validate_dumpling, HUB_HOST, HUB_IN_PORT,
+    HUB_OUT_PORT, HUB_STATUS_FREQ,
 )
 
 
 class DumplingHub:
     """
     Implements a dumpling hub.  A dumpling hub is two websocket servers: one
-    receives dumplings from any number of running `nd-snifty` scripts; and the
+    receives dumplings from any number of running `nd-sniff` scripts; and the
     other sends those dumplings to any number of `dumpling eaters`.  The hub
     also makes its own dumplings which describe its own system status which are
     also sent to all the dumpling eaters at regular intervals.
 
-    `nd-shifty` is a simple wrapper around ``DumplingHub``.
+    `nd-hub` is a simple wrapper around ``DumplingHub``.
     """
     def __init__(
             self,
-            address: str = DEFAULT_SHIFTY_HOST,
-            in_port: int = DEFAULT_SHIFTY_IN_PORT,
-            out_port: int = DEFAULT_SHIFTY_OUT_PORT,
-            status_freq: int = SHIFTY_STATUS_FREQ,
+            address: str = HUB_HOST,
+            in_port: int = HUB_IN_PORT,
+            out_port: int = HUB_OUT_PORT,
+            status_freq: int = HUB_STATUS_FREQ,
     ) -> None:
         """
         :param address: Address the hub is running on.
-        :param in_port: Port used to receive dumplings from `nd-snifty`.
+        :param in_port: Port used to receive dumplings from `nd-sniff`.
         :param out_port: Port used to send dumplings to `dumpling eaters`.
         :param status_freq: Frequency (in secs) to send system status
             dumplings.
@@ -98,8 +98,8 @@ class DumplingHub:
     async def _grab_dumplings(self, websocket, path):
         """
         A coroutine for grabbing dumplings from a single instance of
-        `nd-snifty`.  A single instance of this coroutine exists for each
-        `nd-snifty` and is invoked via :meth:`websockets.server.serve`.
+        `nd-sniff`.  A single instance of this coroutine exists for each
+        `nd-sniff` and is invoked via :meth:`websockets.server.serve`.
 
         :param websocket: A :class:`websockets.server.WebSocketServerProtocol`.
         :param path: Websocket request URI.
@@ -112,7 +112,7 @@ class DumplingHub:
         kitchen = {
             'metadata': {
                 'info_from_kitchen': json.loads(kitchen_json),
-                'info_from_shifty': {
+                'info_from_hub': {
                     'host': host,
                     'port': port
                 }
@@ -178,7 +178,7 @@ class DumplingHub:
         eater = {
             'metadata': {
                 'info_from_eater': json.loads(eater_json),
-                'info_from_shifty': {
+                'info_from_hub': {
                     'host': host,
                     'port': port
                 }
@@ -239,7 +239,7 @@ class DumplingHub:
     def run(self):
         """
         Run the dumpling hub.  Starts two websocket servers: one to receive
-        dumplings from zero or more instances of `nd-snifty`; and another to
+        dumplings from zero or more instances of `nd-sniff`; and another to
         send those dumplings to zero or more dumpling eaters.  Also creates its
         own dumplings at regular intervals to send system status information to
         all connected dumpling eaters.

--- a/netdumplings/dumplingkitchen.py
+++ b/netdumplings/dumplingkitchen.py
@@ -38,7 +38,7 @@ class DumplingKitchen:
             chef_poke_interval: int = 5,
     ) -> None:
         """
-        :param dumpling_queue: Queue for sending dumplings to nd-shifty.
+        :param dumpling_queue: Queue for sending dumplings to the dumpling hub.
         :param name: Kitchen name.
         :param sniffer_filter: PCAP-compliant sniffer filter (``None`` means
             sniff all packets).
@@ -97,7 +97,7 @@ class DumplingKitchen:
         """
         Passes the given network packet to each of the registered
         :class:`DumplingChef` packet handlers. Takes the returned payload and
-        sends it to nd-shifty.
+        sends it to the dumpling hub.
 
         If a packet handler raises an exception then the exception will be
         logged and otherwise ignored.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@ addopts = --cov --cov-report=term --cov-report=html
 
 [coverage:run]
 source = netdumplings
-; ignore the dumpling eaters
-omit =
-    netdumplings/console/printer.py
-    netdumplings/console/shiftydetails.py
-    netdumplings/console/shiftysummary.py
 
 [coverage:html]
 directory = coverage_html

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,11 @@ setup(
     download_url='https://pypi.python.org/pypi/netdumplings',
     entry_points={
         'console_scripts': [
-            'nd-printer=netdumplings.console:printer_cli',
-            'nd-shifty=netdumplings.console:shifty_cli',
-            'nd-shiftydetails=netdumplings.console:shiftydetails_cli',
-            'nd-shiftysummary=netdumplings.console:shiftysummary_cli',
-            'nd-snifty=netdumplings.console:snifty_cli',
+            'nd-hub=netdumplings.console:hub_cli',
+            'nd-hubdetails=netdumplings.console:hubdetails_cli',
+            'nd-hubstatus=netdumplings.console:hubstatus_cli',
+            'nd-print=netdumplings.console:print_cli',
+            'nd-sniff=netdumplings.console:sniff_cli',
         ]
     },
     license='MIT',

--- a/tests/console/test_hub.py
+++ b/tests/console/test_hub.py
@@ -1,14 +1,14 @@
 import click.testing
 
-from netdumplings.console.shifty import shifty_cli
+from netdumplings.console.hub import hub_cli
 from netdumplings.exceptions import NetDumplingsError
 
 
-class TestShifty:
+class TestHub:
     """
-    Test the nd-shifty commandline tool.
+    Test the nd-hub commandline tool.
     """
-    def test_shifty(self, mocker):
+    def test_hub(self, mocker):
         """
         Test that the DumplingHub is instantiated as expected and that run()
         is called.
@@ -17,7 +17,7 @@ class TestShifty:
 
         runner = click.testing.CliRunner()
         result = runner.invoke(
-            shifty_cli,
+            hub_cli,
             [
                 '--address', 'testhost',
                 '--in-port', 1001,
@@ -36,15 +36,15 @@ class TestShifty:
         mock_hub.return_value.run.assert_called_once()
         assert result.exit_code == 0
 
-    def test_shifty_with_error(self, mocker):
+    def test_hub_with_error(self, mocker):
         """
-        Test that a NetDumplingsError in DumplingHub.run() results in shifty
+        Test that a NetDumplingsError in DumplingHub.run() results in the hub
         exiting with status code 1.
         """
         mock_hub = mocker.patch('netdumplings.DumplingHub')
         mock_hub.return_value.run.side_effect = NetDumplingsError
 
         runner = click.testing.CliRunner()
-        result = runner.invoke(shifty_cli)
+        result = runner.invoke(hub_cli)
 
         assert result.exit_code == 1

--- a/tests/console/test_hubdetails.py
+++ b/tests/console/test_hubdetails.py
@@ -1,0 +1,43 @@
+import click.testing
+
+import netdumplings.console.hubdetails as hubdetails
+
+
+class TestHubDetails:
+    """
+    Test the nd-hubdetails commandline tool.
+    """
+    def test_hubdetails(self, mocker):
+        """
+        Test that the DumplingEater is instantiated as expected.
+        """
+        mock_details_eater = mocker.Mock()
+        mock_dumplingeater = mocker.patch(
+            'netdumplings.DumplingEater',
+            return_value=mock_details_eater,
+        )
+
+        eater_name = 'test_eater'
+        hub = 'test_hub'
+
+        runner = click.testing.CliRunner()
+        runner.invoke(
+            hubdetails.hubdetails_cli,
+            [
+                '--eater-name', eater_name,
+                '--hub', hub,
+                '--no-color',
+            ],
+        )
+
+        mock_dumplingeater.assert_called_once_with(
+            name=eater_name,
+            hub=hub,
+            chef_filter=['SystemStatusChef'],
+            on_connect=hubdetails.on_connect,
+            on_dumpling=hubdetails.on_dumpling,
+            on_connection_lost=hubdetails.on_connection_lost,
+        )
+
+        assert hubdetails.PRINT_COLOR is False
+        mock_details_eater.run.assert_called_once_with(dumpling_count=1)

--- a/tests/console/test_hubstatus.py
+++ b/tests/console/test_hubstatus.py
@@ -1,0 +1,43 @@
+import click.testing
+
+import netdumplings.console.hubstatus as hubstatus
+
+
+class TestHubStatus:
+    """
+    Test the nd-hubstatus commandline tool.
+    """
+    def test_hubstatus(self, mocker):
+        """
+        Test that the DumplingEater is instantiated as expected.
+        """
+        mock_status_eater = mocker.Mock()
+        mock_dumplingeater = mocker.patch(
+            'netdumplings.DumplingEater',
+            return_value=mock_status_eater,
+        )
+
+        eater_name = 'test_eater'
+        hub = 'test_hub'
+
+        runner = click.testing.CliRunner()
+        runner.invoke(
+            hubstatus.hubstatus_cli,
+            [
+                '--eater-name', eater_name,
+                '--hub', hub,
+                '--no-color',
+            ],
+        )
+
+        mock_dumplingeater.assert_called_once_with(
+            name=eater_name,
+            hub=hub,
+            chef_filter=['SystemStatusChef'],
+            on_connect=hubstatus.on_connect,
+            on_dumpling=hubstatus.on_dumpling,
+            on_connection_lost=hubstatus.on_connection_lost,
+        )
+
+        assert hubstatus.PRINT_COLOR is False
+        mock_status_eater.run.assert_called_once_with()

--- a/tests/console/test_print.py
+++ b/tests/console/test_print.py
@@ -1,0 +1,57 @@
+import click.testing
+
+from netdumplings.console.print import print_cli
+
+
+class TestPrint:
+    """
+    Test the nd-print commandline tool.
+    """
+    def test_print(self, mocker):
+        """
+        Test that the PrinterEater is instantiated as expected.
+        """
+        mock_eater_instance = mocker.Mock()
+        mock_printereater = mocker.patch(
+            'netdumplings.console.print.PrinterEater',
+            return_value=mock_eater_instance,
+        )
+
+        kitchens = ('TestKitchen1', 'TestKitchen2')
+        interval_dumplings = False
+        packet_dumplings = True
+        contents = True
+        color = True
+        eater_name = 'test_printer'
+        hub = 'test_hub'
+        chefs = ('TestChef1', 'TestChef2')
+
+        runner = click.testing.CliRunner()
+        runner.invoke(
+            print_cli,
+            [
+                '--kitchen', 'TestKitchen1',
+                '--kitchen', 'TestKitchen2',
+                '--no-interval-dumplings',
+                '--packet-dumplings',
+                '--contents',
+                '--color',
+                '--eater-name', 'test_printer',
+                '--hub', 'test_hub',
+                '--chef', 'TestChef1',
+                '--chef', 'TestChef2',
+            ],
+        )
+
+        mock_printereater.assert_called_once_with(
+            kitchens=kitchens,
+            interval_dumplings=interval_dumplings,
+            packet_dumplings=packet_dumplings,
+            contents=contents,
+            color=color,
+            name=eater_name,
+            hub=hub,
+            chefs=chefs,
+        )
+
+        mock_eater_instance.run.assert_called_once_with()

--- a/tests/test_dumplingeater.py
+++ b/tests/test_dumplingeater.py
@@ -7,7 +7,7 @@ import pytest
 import websockets.exceptions
 
 from netdumplings import DumplingEater
-from netdumplings._shared import DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT
+from netdumplings._shared import HUB_HOST, HUB_OUT_PORT
 
 
 # -----------------------------------------------------------------------------
@@ -59,16 +59,14 @@ class TestDumplingEater:
 
         assert eater.name == 'nameless_eater'
         assert eater.chef_filter is None
-        assert eater.shifty_uri == 'ws://{}:{}'.format(
-            DEFAULT_SHIFTY_HOST, DEFAULT_SHIFTY_OUT_PORT
-        )
+        assert eater.hub_ws == 'ws://{}:{}'.format(HUB_HOST, HUB_OUT_PORT)
 
     def test_init_overrides(self):
         """
         Test DumplingEater initialization with overrides.
         """
         test_eater_name = 'test_eater'
-        test_shifty = 'there:1234'
+        test_hub = 'there:1234'
         test_chefs = ['ChefOne', 'ChefTwo', 'ChefThree']
 
         async def test_handler():
@@ -76,7 +74,7 @@ class TestDumplingEater:
 
         eater = DumplingEater(
             name=test_eater_name,
-            shifty=test_shifty,
+            hub=test_hub,
             chef_filter=test_chefs,
             on_connect=test_handler,
             on_dumpling=test_handler,
@@ -85,7 +83,7 @@ class TestDumplingEater:
 
         assert eater.name == test_eater_name
         assert eater.chef_filter == test_chefs
-        assert eater.shifty_uri == 'ws://{}'.format(test_shifty)
+        assert eater.hub_ws == 'ws://{}'.format(test_hub)
         assert eater.on_connect == test_handler
         assert eater.on_dumpling == test_handler
         assert eater.on_connection_lost == test_handler
@@ -121,7 +119,7 @@ class TestDumplingEater:
 
         eater = DumplingEater(
             name='test_eater',
-            shifty='test_shifty',
+            hub='test_hub',
             chef_filter=['ChefOne', 'ChefTwo'],
             on_connect=handler,
             on_dumpling=handler,
@@ -130,7 +128,7 @@ class TestDumplingEater:
         assert repr(eater) == (
             "DumplingEater("
             "name='test_eater', "
-            "shifty='test_shifty', "
+            "hub='test_hub', "
             "chef_filter=['ChefOne', 'ChefTwo'], "
             "on_connect={}, "
             "on_dumpling={}, "
@@ -213,7 +211,7 @@ class TestDumplingEaterGrabDumplings:
 
         eater = DumplingEater(
             name='test_eater',
-            shifty='testshifty:5000',
+            hub='testhub:5000',
             on_connect=asynctest.CoroutineMock(),
             on_dumpling=asynctest.CoroutineMock(),
             on_connection_lost=asynctest.CoroutineMock(),
@@ -221,9 +219,9 @@ class TestDumplingEaterGrabDumplings:
 
         await eater._grab_dumplings(dumpling_count=1)
 
-        # Check that the eater connected to the expected shifty and announced
+        # Check that the eater connected to the expected hub and announced
         # itself.
-        mock_connect.assert_called_with('ws://testshifty:5000')
+        mock_connect.assert_called_with('ws://testhub:5000')
         mock_connect.return_value.send.assert_called_once_with(json.dumps({
             'eater_name': 'test_eater',
         }))

--- a/tests/test_dumplinghub.py
+++ b/tests/test_dumplinghub.py
@@ -285,7 +285,7 @@ class TestDumplingGrabber:
         assert hub._dumpling_kitchens[mock_websocket] == {
             'metadata': {
                 'info_from_kitchen': test_kitchen,
-                'info_from_shifty': {
+                'info_from_hub': {
                     'host': 'kitchenhost',
                     'port': 11111,
                 }
@@ -446,7 +446,7 @@ class TestDumplingEmitter:
         assert hub._dumpling_eaters[mock_websocket] == {
             'metadata': {
                 'info_from_eater': test_eater,
-                'info_from_shifty': {
+                'info_from_hub': {
                     'host': 'eaterhost',
                     'port': 22222,
                 }


### PR DESCRIPTION
Renamed as follows:

* nd-shifty is now nd-hub
* nd-snifty is now nd-sniff
* nd-printer is now nd-print
* nd-shiftydetails is now nd-hubdetails
* nd-shiftysummary is now nd-hubstatus

Includes updates to tests and (minor) doc updates to reflect changes.